### PR TITLE
Merge pull request #1 from rossbar/dev

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,8 @@ release = '0.0.1dev0'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
-    "nbsphinx"
+    "nbsphinx",
+    "recommonmark"
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     install_requires=[
         "sphinx",
         "recommonmark",
-        "nbsphinx"
+        "nbsphinx",
+        "ipython"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
         "sphinx",
         "recommonmark",
         "nbsphinx",
-        "ipython"
+        "ipython",
+        "ipywidgets"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,9 @@ setup(
     include_package_data=True,
     # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
     entry_points={"sphinx.html_themes": ["sphinx_jupyter_book_theme = sphinx_jupyter_book_theme"]},
-    install_requires=["sphinx"],
+    install_requires=[
+        "sphinx",
+        "recommonmark",
+        "nbsphinx"
+    ],
 )


### PR DESCRIPTION
Modifications to the dependencies and `conf.py`.

The added depnendencies to `setup.py` help eliminate some `sphinx-build` warnings, which helps improve the signal-to-noise ratio for warnings that are relevant to the `toc` structure, etc.

Added the `recommonmark` extension to `conf.py` - without it, the `.md` sources are not incorporated by sphinx. Introduces a whole new set of sphinx-build warnings and strange behavior due to impedance mismatches between recommonmark parser and some features (e.g. frontmatter in `md` files), but is necessary to get the sphinx-build system to at least recognize all of the source files.