### PR TITLE
Updated dependency to reflect MyST-NB name-change.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ release = '0.0.1dev0'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
-    "sphinx_notebook",
+    "myst_nb",
     "myst_parser"
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
             "https://github.com/ExecutableBookProject/MyST-NB/archive/master.zip"
         ),
         "ipython",
-        "ipywidgets"
+        "ipywidgets",
+        "ruamel_yaml"
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
     install_requires=[
         "sphinx",
         (
-            "sphinx_notebook @ "
-            "https://github.com/ExecutableBookProject/sphinx_notebook/archive/master.zip"
+            "myst-nb @ "
+            "https://github.com/ExecutableBookProject/MyST-NB/archive/master.zip"
         ),
         "ipython",
         "ipywidgets"


### PR DESCRIPTION
About to test the theme with the [MyST-translation of Elegant Scipy](https://github.com/rossbar/elegant-scipy/tree/myst) I've been playing with - made a quick change to `setup.py` to capture the name change from `sphinx_nb` -> `myst_nb`